### PR TITLE
Support no extension in filename

### DIFF
--- a/%SourceControl/Git/Utils.cls.xml
+++ b/%SourceControl/Git/Utils.cls.xml
@@ -87,6 +87,14 @@ Returns root temp folder</Description>
 ]]></Implementation>
 </Method>
 
+<Method name="IncludeExtensionInFilename">
+<ClassMethod>1</ClassMethod>
+<CodeMode>expression</CodeMode>
+<ReturnType>%Boolean</ReturnType>
+<Implementation><![CDATA[$Get(@..#Storage@("settings","includeExtensionInFilename"), 1)
+]]></Implementation>
+</Method>
+
 <Method name="MappingsNode">
 <ClassMethod>1</ClassMethod>
 <CodeMode>expression</CodeMode>
@@ -339,19 +347,29 @@ adds last slash if not present<br/>]]></Description>
 
     // lower case for extensions
     #dim extension As %String = $ZConvert($Piece(name,".",$Length(name,".")),"L")
-    set $Piece(name,".",$Length(name,".")) = extension
+    #dim baseName As %String = $piece(name,".",1,$length(name,".")-1)
     
-	#dim groupByFolder As %Boolean = ..GroupByFolder()
+    #dim groupByFolder As %Boolean = ..GroupByFolder()
+    if ..IncludeExtensionInFilename() {
+        set extensionSuffix = "." _ extension
+    }
+    else {
+        set extensionSuffix = ""
+    }
+
     // we shall put classes in different folders
     if extension = "cls" {
-       	set name = $Translate( $Piece(name,".", 1, $Length(name,".")-1), ".", ..#Slash)_".cls"
+		set name = $Translate( baseName, ".", ..#Slash) _ extensionSuffix
     } elseif groupByFolder {
 	    // If groupByFolder = 1 then we put inc, mac, int in corresponding folder, not in root.
 		// For example project.include.inc will be placed in project\include.inc.xml
         set sep = $Case(extension, "dfi" : "-", : ".")
-	    set name = $Translate($Piece(name,".", 1, $Length(name,".")-1), sep, ..#Slash)_"." _ extension
+	    set name = $Translate(baseName, sep, ..#Slash) _ extensionSuffix
     }
-        
+    else {
+        set name = baseName _ extensionSuffix
+    }
+    
     // we shall delete csp-app from csp files
     if $Extract(name, 1) = ..#Slash {
         set $Extract(name, 1) = ""
@@ -360,7 +378,8 @@ adds last slash if not present<br/>]]></Description>
         set $Piece(name, ..#Slash, 1, 2) = "csp"
     }
 
-    set mappings = $Data(@..MappingsNode(), rootFolder)
+    set mappingsNode = ..MappingsNode()
+    set mappings = $Data(@mappingsNode, rootFolder)
     
     if mappings#10 = 1 { // value in root
 	    set rootFolder = ..NormalizeFolder(rootFolder)
@@ -369,7 +388,7 @@ adds last slash if not present<br/>]]></Description>
     if mappings >= 10 { //values in leaves
    	    set type = ..Type(InternalName)
    	    
-	    if $Data(@..MappingsNode()@(type), folder) {
+	    if $Data(@mappingsNode@(type), folder) {
 		    set folder = ..NormalizeFolder(folder)
 	    }
     }

--- a/%SourceControl/Git/Utils.cls.xml
+++ b/%SourceControl/Git/Utils.cls.xml
@@ -359,7 +359,7 @@ adds last slash if not present<br/>]]></Description>
 
     // we shall put classes in different folders
     if extension = "cls" {
-		set name = $Translate( baseName, ".", ..#Slash) _ extensionSuffix
+        set name = $Translate( baseName, ".", ..#Slash) _ extensionSuffix
     } elseif groupByFolder {
 	    // If groupByFolder = 1 then we put inc, mac, int in corresponding folder, not in root.
 		// For example project.include.inc will be placed in project\include.inc.xml

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Instead of your-git-server, your-git-login and your-git-password write actual va
 2. Chose menu Create Repo. Press OK. One more time.
 3. Now menu has full view.
 4. A new menu item appears in context menu — "Git -> Add to Source Control".
-5. Chose elements you want to add to Git. These programs, classes, csp-pages etc. are exported to hdd-folder and automatically synchronized with it every time when you open or save them in Studio.
-6. Chose menu Commit.
+5. Choose elements you want to add to Git. These programs, classes, csp-pages etc. are exported to hdd-folder and automatically synchronized with it every time when you open or save them in Studio.
+6. Choose menu Commit.
 7. Select all files, right-click on them and choose "Add".
 8. Write comment and press "Commit"
 9. Now you can immediately push changes to server
@@ -97,5 +97,14 @@ For example:
 In this particular case Caché Git stores all its files (except sc-list.txt) in `src/cache/` subfolder. Classes are stored in `src/cache/cls/` etc. All csp files (including static files -- js, css) are stored in `src/cache/csp-data/`. With this particular path to repository classes will be stored in folder `C:\temp\testctg\src\cache\cls\`.
 
 You can omit root mappings. Mappings for particular item type are still applied.
+
+#### Other Settings
+The following sub-nodes of `^Git("settings")` allow for further configuration:
+* `"groupByFolder"` - boolean value that defaults to `0`. The setting applies to all INC, MAC and INT routines as well as DFI exports.
+  * When this value is true, use nested folders for these files e.g. `Package.Include.INC` would be exported to `<rootfolder>/Package/Include.inc.xml`
+  * When this value is false, all these files are exported to the root folder.
+* `"includeExtensionInFilename"` - boolean value that defaults to `1`.
+  * When true, exported files include the lowercase extension in the filename, e.g. `MyClass.cls.xml`
+  * When false, exported files do not include the extension in the filename, e.g. `MyClass.xml`
 
 NOTE: Caché Git does not do any automatic moving of files. If you have classes placed in root folder and change mappings for cls to "src/cache/cls/" you need to move files corresponding to these classes manually. Better -- set mappings on creating of repository, before adding new items to source control.

--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ You can omit root mappings. Mappings for particular item type are still applied.
 
 #### Other Settings
 The following sub-nodes of `^Git("settings")` allow for further configuration:
-* `"groupByFolder"` - boolean value that defaults to `0`. The setting applies to all INC, MAC and INT routines as well as DFI exports.
-  * When this value is true, use nested folders for these files e.g. `Package.Include.INC` would be exported to `<rootfolder>/Package/Include.inc.xml`
-  * When this value is false, all these files are exported to the root folder.
-* `"includeExtensionInFilename"` - boolean value that defaults to `1`.
+
+* `"groupByFolder"` - boolean value that defaults to `0` when not specified. The setting applies to all INC, MAC and INT routines as well as DFI exports.
+  * When this value is true, use nested folders for these files, e.g. `Package.Include.INC` would be exported to `<rootfolder>/Package/Include.inc.xml`
+  * When this value is false, all these files are exported to the root folder, e.g. `Package.Include.INC` would be exported to `<rootfolder>/Package.Include.inc.xml`
+* `"includeExtensionInFilename"` - boolean value that defaults to `1` when not specified.
   * When true, exported files include the lowercase extension in the filename, e.g. `MyClass.cls.xml`
   * When false, exported files do not include the extension in the filename, e.g. `MyClass.xml`
 


### PR DESCRIPTION
Add new setting to allow exported files to exclude extension in file name. Default keeps existing behaviour, but developers can choose the opposite.

I also cleaned up some of the docs.